### PR TITLE
Refactor names to be more comfy-like

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -87,4 +87,5 @@ class AdaptiveGuidanceGuider:
         return (g,)
 
 
-NODE_CLASS_MAPPINGS = {"AdaptiveGuidanceGuider": AdaptiveGuidanceGuider}
+NODE_CLASS_MAPPINGS = {"AdaptiveGuidance": AdaptiveGuidanceGuider}
+NODE_DISPLAY_NAME_MAPPINGS = {"AdaptiveGuidance": "AdaptiveGuidanceGuider"}

--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ import torch
 cos = torch.nn.CosineSimilarity(dim=1)
 
 
-class AdaptiveGuider(comfy.samplers.CFGGuider):
+class Guider_AdaptiveGuidance(comfy.samplers.CFGGuider):
     threshold_timestep = 0
     uz_scale = 0.0
 
@@ -43,7 +43,7 @@ class AdaptiveGuider(comfy.samplers.CFGGuider):
             # Is this reshape correct? It at least gives a scalar value...
             sim = cos(cond_pred.reshape(1, -1), uncond_pred.reshape(1, -1)).item()
             if sim >= self.threshold:
-                print("AdaptiveGuidance: Cosine similarity", sim, "exceeds threshold, setting CFG to 1.0")
+                print(f"\nAdaptiveGuidance: Cosine similarity {sim:.4f} exceeds threshold, setting CFG to 1.0")
                 self.threshold_timestep = ts
         return comfy.samplers.cfg_function(
             self.inner_model,
@@ -58,7 +58,7 @@ class AdaptiveGuider(comfy.samplers.CFGGuider):
         )
 
 
-class AdaptiveGuidance:
+class AdaptiveGuidanceGuider:
     @classmethod
     def INPUT_TYPES(s):
         return {
@@ -73,12 +73,12 @@ class AdaptiveGuidance:
         }
 
     RETURN_TYPES = ("GUIDER",)
-    FUNCTION = "patch"
+    FUNCTION = "get_guider"
 
     CATEGORY = "sampling/custom_sampling/guiders"
 
-    def patch(self, model, positive, negative, threshold, cfg, uncond_zero_scale=0.0):
-        g = AdaptiveGuider(model)
+    def get_guider(self, model, positive, negative, threshold, cfg, uncond_zero_scale=0.0):
+        g = Guider_AdaptiveGuidance(model)
         g.set_conds(positive, negative)
         g.set_threshold(threshold)
         g.set_uncond_zero_scale(uncond_zero_scale)
@@ -87,4 +87,4 @@ class AdaptiveGuidance:
         return (g,)
 
 
-NODE_CLASS_MAPPINGS = {"AdaptiveGuidance": AdaptiveGuidance}
+NODE_CLASS_MAPPINGS = {"AdaptiveGuidanceGuider": AdaptiveGuidanceGuider}


### PR DESCRIPTION
Change the name of class and function to align the comfy's naming. (examples: class Guider_Basic <-> node BasicGuider, class Guider_DualCFG <-> node DualCFGGuider)

Use f-string instead of comma separated print. And since the step of threshold is 0.001, use .4f to avoid printing the whole floating digits.

