### PR TITLE
Bring the "default" speed back at CFG = 1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,6 +26,11 @@ class Guider_AdaptiveGuidance(comfy.samplers.CFGGuider):
         return x - (cond / cond.std() ** 0.5) * self.uz_scale
 
     def predict_noise(self, x, timestep, model_options={}, seed=None):
+        if self.cfg == 1.0:
+            cond = self.conds.get("positive")
+            return comfy.samplers.sampling_function(
+                self.inner_model, x, timestep, cond, cond, 1.0, model_options=model_options, seed=seed
+            )
         cond = self.conds.get("positive")
         uncond = self.conds.get("negative")
         ts = timestep[0].item()
@@ -91,7 +96,11 @@ class AdaptiveGuidanceGuider:
 class Guider_PerpNegAG(comfy_extras.nodes_perpneg.Guider_PerpNeg):
     threshold_timestep = 0
     uz_scale = 0.0
-
+    
+    def set_cfg(self, cfg, neg_scale):
+        self.cfg = cfg
+        self.neg_scale = neg_scale
+        
     def set_threshold(self, threshold):
         self.threshold = threshold
 
@@ -106,6 +115,11 @@ class Guider_PerpNegAG(comfy_extras.nodes_perpneg.Guider_PerpNeg):
         return x - (cond / cond.std() ** 0.5) * self.uz_scale
 
     def predict_noise(self, x, timestep, model_options={}, seed=None):
+        if self.cfg == 1.0:
+            cond = self.conds.get("positive")
+            return comfy.samplers.sampling_function(
+                self.inner_model, x, timestep, cond, cond, 1.0, model_options=model_options, seed=seed
+            )
         cond = self.conds.get("positive")
         uncond = self.conds.get("negative")
         ts = timestep[0].item()

--- a/__init__.py
+++ b/__init__.py
@@ -92,7 +92,6 @@ class AdaptiveGuidanceGuider:
 
         return (g,)
 
-
 class Guider_PerpNegAG(comfy_extras.nodes_perpneg.Guider_PerpNeg):
     threshold_timestep = 0
     uz_scale = 0.0

--- a/__init__.py
+++ b/__init__.py
@@ -96,10 +96,6 @@ class AdaptiveGuidanceGuider:
 class Guider_PerpNegAG(comfy_extras.nodes_perpneg.Guider_PerpNeg):
     threshold_timestep = 0
     uz_scale = 0.0
-    
-    def set_cfg(self, cfg, neg_scale):
-        self.cfg = cfg
-        self.neg_scale = neg_scale
         
     def set_threshold(self, threshold):
         self.threshold = threshold
@@ -115,11 +111,6 @@ class Guider_PerpNegAG(comfy_extras.nodes_perpneg.Guider_PerpNeg):
         return x - (cond / cond.std() ** 0.5) * self.uz_scale
 
     def predict_noise(self, x, timestep, model_options={}, seed=None):
-        if self.cfg == 1.0:
-            cond = self.conds.get("positive")
-            return comfy.samplers.sampling_function(
-                self.inner_model, x, timestep, cond, cond, 1.0, model_options=model_options, seed=seed
-            )
         cond = self.conds.get("positive")
         uncond = self.conds.get("negative")
         ts = timestep[0].item()


### PR DESCRIPTION
Hello,

When using your "AdaptiveGuider" node, I realized that when I put the cfg value at 1, the speed is the same as the speed at CFG > 1, and that shouldn't be the case at all. For example the classic "CFGGuider" node has the fastest speed at CFG = 1.

My code fixes that by bypassing the calculations of "AdaptiveGuider" at CFG = 1 (Because at that state, this node doesn't need to do anything).